### PR TITLE
Setup Initial Business Methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "luxon-business-days",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6153,6 +6153,12 @@
         "yallist": "^3.0.2"
       }
     },
+    "luxon": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.17.2.tgz",
+      "integrity": "sha512-qELKtIj3HD41N+MvgoxArk8DZGUb4Gpiijs91oi+ZmKJzRlxY6CoyTwNoUwnogCVs4p8HuxVJDik9JbnYgrCng==",
+      "dev": true
+    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "luxon-business-days",
   "version": "1.2.0",
-  "description": "Luxon plugin to",
+  "description": "Luxon plugin to manipulate time through business days",
   "main": "dist/index.js",
   "scripts": {
     "lint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "lint": "eslint src",
     "test": "jest",
+    "test:watch": "NODE_ENV=test jest --watch --coverage=false",
+    "test:coverage": "NODE_ENV=test jest --watch",
     "clean": "rimraf dist",
     "build": "webpack",
     "prepare": "npm run clean && npm run lint && npm run build"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "luxon-business-days",
   "version": "1.2.0",
-  "description": "",
+  "description": "Luxon plugin to",
   "main": "dist/index.js",
   "scripts": {
     "lint": "eslint src",
@@ -20,6 +20,9 @@
     "url": "https://github.com/amaidah/luxon-business-days/issues"
   },
   "homepage": "https://github.com/amaidah/luxon-business-days#readme",
+  "peerDependencies": {
+    "luxon": "1.17.x"
+  },
   "devDependencies": {
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
@@ -30,6 +33,7 @@
     "husky": "^3.0.4",
     "jest": "^24.9.0",
     "lint-staged": "^9.2.4",
+    "luxon": "^1.17.2",
     "prettier": "^1.18.2",
     "rimraf": "^3.0.0",
     "webpack": "^4.39.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luxon-business-days",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,0 +1,2 @@
+export const DEFAULT_BUSINESS_DAYS = [1, 2, 3, 4, 5];
+export const DEFAULT_HOLIDAYS = [];

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,38 @@
-const helloWorld = () => {
-  return 'Hello World';
+if (typeof require === 'function') {
+  var { DateTime } = require('luxon');
+}
+
+const DEFAULT_BUSINESS_DAYS = [1, 2, 3, 4, 5];
+
+// Object.defineProperty(DateTime, 'businessDays', {
+//   get: function() {
+//     return this.businessDays;
+//   },
+//   set: function(newBusinessDays) {
+//     this.businessDays = newBusinessDays;
+//   },
+// });
+
+// DateTime.prototype.defineBusinessDays = function(businessDays) {
+//   this.businessDays = businessDays;
+// };
+
+// DateTime.prototype.getBusinessDays = function() {
+//   console.log(this.businessDays);
+//   return this.businessDays;
+// };
+
+DateTime.prototype.setupBusiness = function(config) {
+  const { businessDays, holidays } = config;
+
+  this.businessDays = businessDays;
+  this.holidays = holidays;
 };
 
-export default helloWorld;
+DateTime.prototype.isBusinessDay = function() {
+  const defaultBusinessDays = this.businessDays || DEFAULT_BUSINESS_DAYS;
+
+  return defaultBusinessDays.includes(this.weekday);
+};
+
+export { DateTime };

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,21 @@
-if (typeof require === 'function') {
-  var { DateTime } = require('luxon');
-}
+import { DEFAULT_BUSINESS_DAYS, DEFAULT_HOLIDAYS } from './defaults';
 
-const DEFAULT_BUSINESS_DAYS = [1, 2, 3, 4, 5];
+// if (typeof require === 'function') {
+var { DateTime } = require('luxon');
+// }
 
-DateTime.prototype.setupBusiness = function(config) {
-  const { businessDays, holidays } = config;
-
-  this.businessDays = businessDays;
-  this.holidays = holidays;
+DateTime.prototype.setupBusiness = function({
+  businessDays = DEFAULT_BUSINESS_DAYS,
+  holidays = DEFAULT_HOLIDAYS,
+} = {}) {
+  // luxon is immutable so we add our config to the chain
+  // so we can maintain access across new instances
+  DateTime.prototype.businessDays = businessDays;
+  DateTime.prototype.holidays = holidays;
 };
 
 DateTime.prototype.isBusinessDay = function() {
+  console.log('this.businessDays', this.businessDays);
   const defaultBusinessDays = this.businessDays || DEFAULT_BUSINESS_DAYS;
 
   return defaultBusinessDays.includes(this.weekday);

--- a/src/index.js
+++ b/src/index.js
@@ -8,17 +8,24 @@ DateTime.prototype.setupBusiness = function({
   businessDays = DEFAULT_BUSINESS_DAYS,
   holidays = DEFAULT_HOLIDAYS,
 } = {}) {
-  // luxon is immutable so we add our config to the chain
-  // so we can maintain access across new instances
+  /**
+   * luxon does not clone custom properties so to maintain
+   * config access across new instances we add our config
+   * to the chain as a workaround
+   * https://github.com/moment/luxon/blob/master/src/datetime.js#L62
+   */
   DateTime.prototype.businessDays = businessDays;
   DateTime.prototype.holidays = holidays;
 };
 
 DateTime.prototype.isBusinessDay = function() {
-  console.log('this.businessDays', this.businessDays);
   const defaultBusinessDays = this.businessDays || DEFAULT_BUSINESS_DAYS;
 
   return defaultBusinessDays.includes(this.weekday);
 };
 
-export { DateTime };
+if (typeof module != 'undefined' && module.exports) {
+  module.exports = { DateTime };
+}
+
+// export { DateTime };

--- a/src/index.js
+++ b/src/index.js
@@ -4,24 +4,6 @@ if (typeof require === 'function') {
 
 const DEFAULT_BUSINESS_DAYS = [1, 2, 3, 4, 5];
 
-// Object.defineProperty(DateTime, 'businessDays', {
-//   get: function() {
-//     return this.businessDays;
-//   },
-//   set: function(newBusinessDays) {
-//     this.businessDays = newBusinessDays;
-//   },
-// });
-
-// DateTime.prototype.defineBusinessDays = function(businessDays) {
-//   this.businessDays = businessDays;
-// };
-
-// DateTime.prototype.getBusinessDays = function() {
-//   console.log(this.businessDays);
-//   return this.businessDays;
-// };
-
 DateTime.prototype.setupBusiness = function(config) {
   const { businessDays, holidays } = config;
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,9 @@ DateTime.prototype.setupBusiness = function({
    * config access across new instances we add our config
    * to the chain as a workaround
    * https://github.com/moment/luxon/blob/master/src/datetime.js#L62
+   *
+   * The limitation to this is that this plugin can only support one
+   * business setup at a time currently
    */
   DateTime.prototype.businessDays = businessDays;
   DateTime.prototype.holidays = holidays;

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,6 @@
-import { DEFAULT_BUSINESS_DAYS, DEFAULT_HOLIDAYS } from './defaults';
+import { DateTime } from 'luxon';
 
-// if (typeof require === 'function') {
-var { DateTime } = require('luxon');
-// }
+import { DEFAULT_BUSINESS_DAYS, DEFAULT_HOLIDAYS } from './defaults';
 
 DateTime.prototype.setupBusiness = function({
   businessDays = DEFAULT_BUSINESS_DAYS,
@@ -24,8 +22,4 @@ DateTime.prototype.isBusinessDay = function() {
   return defaultBusinessDays.includes(this.weekday);
 };
 
-if (typeof module != 'undefined' && module.exports) {
-  module.exports = { DateTime };
-}
-
-// export { DateTime };
+export { DateTime };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,19 +1,9 @@
 import { DateTime } from './index';
 import { DEFAULT_BUSINESS_DAYS, DEFAULT_HOLIDAYS } from './defaults';
 
-// clone really means, "make a new object with these modifications". all "setters" really use this
-// to create a new object while only changing some of the properties
-// function clone(inst, alts) {
-//   const current = {
-//     ts: inst.ts,
-//     zone: inst.zone,
-//     c: inst.c,
-//     o: inst.o,
-//     loc: inst.loc,
-//     invalid: inst.invalid
-//   };
-//   return new DateTime(Object.assign({}, current, alts, { old: current }));
-// }
+beforeEach(() => {
+  resetGlobalDateTimeBusinessSetup();
+});
 
 describe('setupBusiness()', () => {
   it('sets the default business days when called with no arguments', () => {
@@ -26,22 +16,34 @@ describe('setupBusiness()', () => {
   it('can override default business days with a config object', () => {
     const dt = DateTime.local();
     dt.setupBusiness({ businessDays: [1, 3, 5, 6] });
-    const next = dt.plus({ days: 1 });
-
-    console.log(next.businessDays);
-
-    console.log(next.isBusinessDay());
 
     expect(dt.businessDays).toEqual([1, 3, 5, 6]);
+  });
+
+  it('will persist custom config through new instances', () => {
+    const today = DateTime.local();
+    today.setupBusiness({ businessDays: [2, 3, 6, 7] });
+    const tomorrow = today.plus({ days: 1 });
+
+    expect(today.businessDays).toEqual([2, 3, 6, 7]);
+    expect(tomorrow.businessDays).toEqual([2, 3, 6, 7]);
+  });
+
+  it('unfortunately overwrites business setup config across instances', () => {
+    const today = DateTime.local();
+    today.setupBusiness({ businessDays: [2, 3, 6, 7] });
+    const tomorrow = today.plus({ days: 1 });
+    tomorrow.setupBusiness({ businessDays: [1] });
+
+    expect(today.businessDays).toEqual([1]);
+    expect(tomorrow.businessDays).toEqual([1]);
   });
 
   // TODO: test for holidays setup
 });
 
 describe('isBusinessDay()', () => {
-  xit('knows mon-fri are the default business days', () => {
-    const dt = DateTime.local(2019, 8, 26);
-    console.log(dt);
+  it('knows mon-fri are the default business days', () => {
     const days = {
       monday: { dt: DateTime.local(2019, 8, 26), isBusinessDay: true },
       tuesday: { dt: DateTime.local(2019, 8, 27), isBusinessDay: true },
@@ -57,26 +59,30 @@ describe('isBusinessDay()', () => {
     });
   });
 
-  xit('knows when overridden business settings are business days', () => {
-    let dt = DateTime.local(2019, 8, 26);
+  it('knows when overridden business settings are business days', () => {
+    const monday = [2019, 8, 26];
+    let dt = DateTime.local(...monday);
     dt.setupBusiness({ businessDays: [2, 4, 7] });
-    dt.plus({ days: 1 });
-    console.log(dt.plus({ days: 2 }));
-    console.log(dt.businessDays);
+
     const days = {
-      monday: { dt: dt, isBusinessDay: false },
-      tuesday: { dt: dt.plus({ days: 1 }), isBusinessDay: true },
-      wednesday: { dt: dt.plus({ days: 2 }), isBusinessDay: false },
-      thursday: { dt: dt.plus({ days: 3 }), isBusinessDay: true },
-      friday: { dt: dt.plus({ days: 4 }), isBusinessDay: false },
-      saturday: { dt: dt.plus({ days: 5 }), isBusinessDay: false },
-      sunday: { dt: dt.plus({ days: 6 }), isBusinessDay: true },
+      monday: { isBusinessDay: false },
+      tuesday: { isBusinessDay: true },
+      wednesday: { isBusinessDay: false },
+      thursday: { isBusinessDay: true },
+      friday: { isBusinessDay: false },
+      saturday: { isBusinessDay: false },
+      sunday: { isBusinessDay: true },
     };
 
-    Object.values(days).forEach(({ dt, isBusinessDay }, i) => {
-      // console.log(i);
-      // console.log(dt);
+    Object.values(days).forEach(({ isBusinessDay }) => {
       expect(dt.isBusinessDay()).toEqual(isBusinessDay);
+
+      dt = dt.plus({ days: 1 });
     });
   });
 });
+
+function resetGlobalDateTimeBusinessSetup() {
+  const dt = DateTime.local();
+  dt.setupBusiness();
+}

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,3 @@
-import helloWorld from './index';
-
-it('prints "Hello World"', () => {
-  expect(helloWorld()).toEqual('Hello World');
+it('boilerplate', () => {
+  expect(1).toBe(1);
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,3 +1,82 @@
-it('boilerplate', () => {
-  expect(1).toBe(1);
+import { DateTime } from './index';
+import { DEFAULT_BUSINESS_DAYS, DEFAULT_HOLIDAYS } from './defaults';
+
+// clone really means, "make a new object with these modifications". all "setters" really use this
+// to create a new object while only changing some of the properties
+// function clone(inst, alts) {
+//   const current = {
+//     ts: inst.ts,
+//     zone: inst.zone,
+//     c: inst.c,
+//     o: inst.o,
+//     loc: inst.loc,
+//     invalid: inst.invalid
+//   };
+//   return new DateTime(Object.assign({}, current, alts, { old: current }));
+// }
+
+describe('setupBusiness()', () => {
+  it('sets the default business days when called with no arguments', () => {
+    let dt = DateTime.local();
+    dt.setupBusiness();
+
+    expect(dt.businessDays).toEqual(DEFAULT_BUSINESS_DAYS);
+  });
+
+  it('can override default business days with a config object', () => {
+    const dt = DateTime.local();
+    dt.setupBusiness({ businessDays: [1, 3, 5, 6] });
+    const next = dt.plus({ days: 1 });
+
+    console.log(next.businessDays);
+
+    console.log(next.isBusinessDay());
+
+    expect(dt.businessDays).toEqual([1, 3, 5, 6]);
+  });
+
+  // TODO: test for holidays setup
+});
+
+describe('isBusinessDay()', () => {
+  xit('knows mon-fri are the default business days', () => {
+    const dt = DateTime.local(2019, 8, 26);
+    console.log(dt);
+    const days = {
+      monday: { dt: DateTime.local(2019, 8, 26), isBusinessDay: true },
+      tuesday: { dt: DateTime.local(2019, 8, 27), isBusinessDay: true },
+      wednesday: { dt: DateTime.local(2019, 8, 28), isBusinessDay: true },
+      thursday: { dt: DateTime.local(2019, 8, 29), isBusinessDay: true },
+      friday: { dt: DateTime.local(2019, 8, 30), isBusinessDay: true },
+      saturday: { dt: DateTime.local(2019, 8, 31), isBusinessDay: false },
+      sunday: { dt: DateTime.local(2019, 9, 1), isBusinessDay: false },
+    };
+
+    Object.values(days).forEach(({ dt, isBusinessDay }) => {
+      expect(dt.isBusinessDay()).toEqual(isBusinessDay);
+    });
+  });
+
+  xit('knows when overridden business settings are business days', () => {
+    let dt = DateTime.local(2019, 8, 26);
+    dt.setupBusiness({ businessDays: [2, 4, 7] });
+    dt.plus({ days: 1 });
+    console.log(dt.plus({ days: 2 }));
+    console.log(dt.businessDays);
+    const days = {
+      monday: { dt: dt, isBusinessDay: false },
+      tuesday: { dt: dt.plus({ days: 1 }), isBusinessDay: true },
+      wednesday: { dt: dt.plus({ days: 2 }), isBusinessDay: false },
+      thursday: { dt: dt.plus({ days: 3 }), isBusinessDay: true },
+      friday: { dt: dt.plus({ days: 4 }), isBusinessDay: false },
+      saturday: { dt: dt.plus({ days: 5 }), isBusinessDay: false },
+      sunday: { dt: dt.plus({ days: 6 }), isBusinessDay: true },
+    };
+
+    Object.values(days).forEach(({ dt, isBusinessDay }, i) => {
+      // console.log(i);
+      // console.log(dt);
+      expect(dt.isBusinessDay()).toEqual(isBusinessDay);
+    });
+  });
 });


### PR DESCRIPTION
- Add `.setupBusiness()`
  - Luxon does not clone custom properties so to maintain config access across new instances we add our config to the chain as a workaround. The limitation here is that this plugin can only support one business setup at a time at the moment.
   - https://github.com/moment/luxon/blob/master/src/datetime.js#L62
- Add `.isBusinessDay()`
  - Has no implementation for checking holidays that fall during normal business days