### PR TITLE
Remove luxon from distributed bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8792,6 +8792,12 @@
         }
       }
     },
+    "webpack-node-externals": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
+      "integrity": "sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==",
+      "dev": true
+    },
     "webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "prettier": "^1.18.2",
     "rimraf": "^3.0.0",
     "webpack": "^4.39.2",
-    "webpack-cli": "^3.3.7"
+    "webpack-cli": "^3.3.7",
+    "webpack-node-externals": "^1.7.2"
   },
   "husky": {
     "hooks": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const nodeExternals = require('webpack-node-externals');
 
 module.exports = {
   mode: 'production',
@@ -17,12 +18,14 @@ module.exports = {
           loader: 'babel-loader',
           options: {
             presets: ['@babel/preset-env'],
-          }
-        }
-      }
-    ]
+          },
+        },
+      },
+    ],
   },
   resolve: {
     extensions: ['.js'],
-  }
-}
+  },
+  target: 'node',
+  externals: [nodeExternals()],
+};


### PR DESCRIPTION
- Add `webpack-node-externals` pkg to remove `luxon` from being bundled into the distributed webpack output
- Dist size from 68kb to 1kb!