### PR TITLE
Add utility methods for figuring out holidays

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,3 +1,5 @@
+import * as holidays from './holidays';
+
+export const ONE_DAY = 1;
 export const DEFAULT_BUSINESS_DAYS = [1, 2, 3, 4, 5];
 export const DEFAULT_HOLIDAYS = [];
-export const ONE_DAY = 1;

--- a/src/holidays.js
+++ b/src/holidays.js
@@ -1,0 +1,8 @@
+import { DateTime } from 'luxon';
+
+export const isNewYearsDay = function(inst) {
+  const matchesMonth = inst.month === 1;
+  const matchesDay = inst.day === 1;
+
+  return matchesMonth && matchesDay;
+};

--- a/src/holidays.js
+++ b/src/holidays.js
@@ -6,3 +6,25 @@ export const isNewYearsDay = function(inst) {
 
   return matchesMonth && matchesDay;
 };
+
+// last Monday of May
+export const isMemorialDay = function(inst) {
+  const DAYS_IN_MAY = 31;
+  const MONTH_OF_MAY = 5;
+  const isMatchingMonth = inst.month === MONTH_OF_MAY;
+
+  if (!isMatchingMonth) {
+    return false;
+  }
+
+  const instanceYear = inst.year;
+  const lastDayInMay = DateTime.fromObject({
+    year: instanceYear,
+    month: MONTH_OF_MAY,
+    day: DAYS_IN_MAY,
+  });
+  const weekday = lastDayInMay.weekday;
+  const memorialDay = lastDayInMay.minus({ days: weekday - 1 });
+
+  return +inst === +memorialDay;
+};

--- a/src/holidays.test.js
+++ b/src/holidays.test.js
@@ -20,3 +20,28 @@ describe('isNewYearsDay()', () => {
     });
   });
 });
+
+describe('isMemorialDay()', () => {
+  it('early returns false if a date time instance is not in may', () => {
+    const dayInFeb = DateTime.fromObject({ month: 2, day: 3 });
+
+    expect(holidays.isMemorialDay(dayInFeb)).toEqual(false);
+  });
+
+  it('knows a Memorial Day of any year', () => {
+    const memorial2019 = DateTime.fromObject({ year: 2019, month: 5, day: 27 });
+    const memorial2017 = DateTime.fromObject({ year: 2017, month: 5, day: 29 });
+    const memorial1988 = DateTime.fromObject({ year: 1988, month: 5, day: 30 });
+    const memorial2020 = DateTime.fromObject({ year: 2020, month: 5, day: 25 });
+    const memorialDays = [
+      memorial2019,
+      memorial2017,
+      memorial1988,
+      memorial2020,
+    ];
+
+    memorialDays.forEach(day => {
+      expect(holidays.isMemorialDay(day)).toEqual(true);
+    });
+  });
+});

--- a/src/holidays.test.js
+++ b/src/holidays.test.js
@@ -1,0 +1,22 @@
+import { DateTime } from './index';
+import * as holidays from './holidays';
+
+describe('isNewYearsDay()', () => {
+  it('knows if a date time instance is New Years Day', () => {
+    const notNewYearsDay = DateTime.fromObject({ month: 4, day: 14 });
+
+    expect(holidays.isNewYearsDay(notNewYearsDay)).toEqual(false);
+  });
+
+  it('knows a New Years Day of any year', () => {
+    const nyd2019 = DateTime.fromObject({ year: 2019, month: 1, day: 1 });
+    const nyd2016 = DateTime.fromObject({ year: 2016, month: 1, day: 1 });
+    const nyd1988 = DateTime.fromObject({ year: 1988, month: 1, day: 1 });
+    const nyd2022 = DateTime.fromObject({ year: 2022, month: 1, day: 1 });
+    const newYearsDays = [nyd2019, nyd2016, nyd1988, nyd2022];
+
+    newYearsDays.forEach(day => {
+      expect(holidays.isNewYearsDay(day)).toEqual(true);
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,10 @@ DateTime.prototype.clearBusinessSetup = function() {
   delete DateTime.prototype.holidays;
 };
 
+DateTime.prototype.isHoliday = function() {
+  return false;
+};
+
 DateTime.prototype.isBusinessDay = function() {
   const businessDays = this.businessDays || DEFAULT_BUSINESS_DAYS;
 


### PR DESCRIPTION
- Add `isNewYearsDay()`
- Add `isMemorialDay()`

Both take an instance of `Date Time` and return a boolean.

Memorial Day is calculated by subtracting backwards from the last day in May until the first Monday is reached.