### PR TITLE
Reclassify and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,69 +232,44 @@ dt.isHoliday('middle-america', {some: 'stuff'});
 
 ## API
 
-## Modules
-
-<dl>
-<dt><a href="#module_holidayHelpers">holidayHelpers</a></dt>
-<dd></dd>
-</dl>
-
 ## Members
 
 <dl>
-<dt><a href="#availableHolidayMatchers">availableHolidayMatchers</a> : <code>Object</code></dt>
-<dd><p>All built-in holiday matchers.</p>
-</dd>
-<dt><a href="#availableHolidayHelpers">availableHolidayHelpers</a> : <code>Object</code></dt>
-<dd><p>Exposes all available holiday helpers to a DateTime instance.</p>
-</dd>
+<dt><a href="#DateTime">DateTime</a> ⇐ <code><a href="#DateTime">DateTime</a></code></dt>
+<dd></dd>
 </dl>
 
 ## Functions
 
 <dl>
-<dt><a href="#setupBusiness">setupBusiness([businessDays], [holidayMatchers])</a> ⇐ <code>DateTime</code></dt>
-<dd><p>Sets up business days and holiday matchers globally for all DateTime instances.</p>
-</dd>
-<dt><a href="#clearBusinessSetup">clearBusinessSetup()</a> ⇐ <code>DateTime</code></dt>
-<dd><p>Clears business setup globally from all DateTime instances.</p>
-</dd>
-<dt><a href="#isHoliday">isHoliday([...args])</a> ⇒ <code>boolean</code></dt>
-<dd><p>Checks if DateTime instance is a holiday by checking against all holiday matchers.</p>
-</dd>
-<dt><a href="#isBusinessDay">isBusinessDay()</a> ⇒ <code>boolean</code></dt>
-<dd><p>Checks if DateTime instance is a business day.</p>
-</dd>
-<dt><a href="#plusBusiness">plusBusiness([days])</a> ⇒ <code>DateTime</code></dt>
-<dd><p>Adds business days to an existing DateTime instance.</p>
-</dd>
-<dt><a href="#minusBusiness">minusBusiness([days])</a> ⇒ <code>DateTime</code></dt>
-<dd><p>Subtracts business days to an existing DateTime instance.</p>
+<dt><a href="#getEasterMonthAndDay">getEasterMonthAndDay(year)</a> ⇒ <code>Array</code></dt>
+<dd><p>Returns the month and day of Easter for a given year.</p>
 </dd>
 </dl>
 
-<a name="module_holidayHelpers"></a>
+<a name="DateTime"></a>
 
-## holidayHelpers
-<a name="module_holidayHelpers.getEasterMonthAndDay"></a>
+## DateTime ⇐ [<code>DateTime</code>](#DateTime)
+**Kind**: global variable  
+**Extends**: [<code>DateTime</code>](#DateTime)  
 
-### holidayHelpers.getEasterMonthAndDay(year) ⇒ <code>Array</code>
-Returns the month and Day of Easter for a given year.
+* [DateTime](#DateTime) ⇐ [<code>DateTime</code>](#DateTime)
+    * [.availableHolidayMatchers](#DateTime+availableHolidayMatchers) : <code>Object</code>
+    * [.availableHolidayHelpers](#DateTime+availableHolidayHelpers) : <code>Object</code>
+    * [.setupBusiness([businessDays], [holidayMatchers])](#DateTime+setupBusiness) ⇐ [<code>DateTime</code>](#DateTime)
+    * [.clearBusinessSetup()](#DateTime+clearBusinessSetup) ⇐ [<code>DateTime</code>](#DateTime)
+    * [.isHoliday([...args])](#DateTime+isHoliday) ⇒ <code>boolean</code>
+    * [.isBusinessDay()](#DateTime+isBusinessDay) ⇒ <code>boolean</code>
+    * [.plusBusiness([days])](#DateTime+plusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
+    * [.minusBusiness([days])](#DateTime+minusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
 
-**Kind**: static method of [<code>holidayHelpers</code>](#module_holidayHelpers)  
-**Returns**: <code>Array</code> - Returns the exact month and day via `[month, day]`.  
+<a name="DateTime+availableHolidayMatchers"></a>
 
-| Param | Type |
-| --- | --- |
-| year | <code>number</code> | 
-
-<a name="availableHolidayMatchers"></a>
-
-## availableHolidayMatchers : <code>Object</code>
+### dateTime.availableHolidayMatchers : <code>Object</code>
 All built-in holiday matchers.
 
-**Kind**: global variable  
-**Extends**: <code>DateTime</code>  
+**Kind**: instance property of [<code>DateTime</code>](#DateTime)  
+**Extends**: [<code>DateTime</code>](#DateTime)  
 **Properties**
 
 | Name | Type | Description |
@@ -309,80 +284,91 @@ All built-in holiday matchers.
 | isThanksgivingDay | <code>function</code> | A provided holiday matcher. |
 | isChristmasDay | <code>function</code> | A provided holiday matcher. |
 
-<a name="availableHolidayHelpers"></a>
+<a name="DateTime+availableHolidayHelpers"></a>
 
-## availableHolidayHelpers : <code>Object</code>
+### dateTime.availableHolidayHelpers : <code>Object</code>
 Exposes all available holiday helpers to a DateTime instance.
 
-**Kind**: global variable  
-**Extends**: <code>DateTime</code>  
-**See**: [holidayHelpers](#module_holidayHelpers)  
+**Kind**: instance property of [<code>DateTime</code>](#DateTime)  
+**Extends**: [<code>DateTime</code>](#DateTime)  
 **Properties**
 
 | Name | Type | Description |
 | --- | --- | --- |
 | getEasterMonthAndDay | <code>function</code> | A provided holiday helper function that can be helpful for custom holiday matchers. |
 
-<a name="setupBusiness"></a>
+<a name="DateTime+setupBusiness"></a>
 
-## setupBusiness([businessDays], [holidayMatchers]) ⇐ <code>DateTime</code>
+### dateTime.setupBusiness([businessDays], [holidayMatchers]) ⇐ [<code>DateTime</code>](#DateTime)
 Sets up business days and holiday matchers globally for all DateTime instances.
 
-**Kind**: global function  
-**Extends**: <code>DateTime</code>  
+**Kind**: instance method of [<code>DateTime</code>](#DateTime)  
+**Extends**: [<code>DateTime</code>](#DateTime)  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | [businessDays] | <code>Array.&lt;number&gt;</code> | <code>DEFAULT_BUSINESS_DAYS</code> | The working business days for the business. |
 | [holidayMatchers] | <code>Array.&lt;function()&gt;</code> | <code>DEFAULT_HOLIDAY_MATCHERS</code> | The holiday matchers used to check if a particular day is a holiday for the business. |
 
-<a name="clearBusinessSetup"></a>
+<a name="DateTime+clearBusinessSetup"></a>
 
-## clearBusinessSetup() ⇐ <code>DateTime</code>
+### dateTime.clearBusinessSetup() ⇐ [<code>DateTime</code>](#DateTime)
 Clears business setup globally from all DateTime instances.
 
-**Kind**: global function  
-**Extends**: <code>DateTime</code>  
-<a name="isHoliday"></a>
+**Kind**: instance method of [<code>DateTime</code>](#DateTime)  
+**Extends**: [<code>DateTime</code>](#DateTime)  
+<a name="DateTime+isHoliday"></a>
 
-## isHoliday([...args]) ⇒ <code>boolean</code>
+### dateTime.isHoliday([...args]) ⇒ <code>boolean</code>
 Checks if DateTime instance is a holiday by checking against all holiday matchers.
 
-**Kind**: global function  
-**Extends**: <code>DateTime</code>  
+**Kind**: instance method of [<code>DateTime</code>](#DateTime)  
+**Extends**: [<code>DateTime</code>](#DateTime)  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | [...args] | <code>\*</code> | Any additional arguments to pass through to each holiday matcher. |
 
-<a name="isBusinessDay"></a>
+<a name="DateTime+isBusinessDay"></a>
 
-## isBusinessDay() ⇒ <code>boolean</code>
+### dateTime.isBusinessDay() ⇒ <code>boolean</code>
 Checks if DateTime instance is a business day.
 
-**Kind**: global function  
-**Extends**: <code>DateTime</code>  
-<a name="plusBusiness"></a>
+**Kind**: instance method of [<code>DateTime</code>](#DateTime)  
+**Extends**: [<code>DateTime</code>](#DateTime)  
+<a name="DateTime+plusBusiness"></a>
 
-## plusBusiness([days]) ⇒ <code>DateTime</code>
+### dateTime.plusBusiness([days]) ⇒ [<code>DateTime</code>](#DateTime)
 Adds business days to an existing DateTime instance.
 
-**Kind**: global function  
-**Extends**: <code>DateTime</code>  
+**Kind**: instance method of [<code>DateTime</code>](#DateTime)  
+**Extends**: [<code>DateTime</code>](#DateTime)  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | [days] | <code>number</code> | <code>1</code> | The number of business days to add. |
 
-<a name="minusBusiness"></a>
+<a name="DateTime+minusBusiness"></a>
 
-## minusBusiness([days]) ⇒ <code>DateTime</code>
+### dateTime.minusBusiness([days]) ⇒ [<code>DateTime</code>](#DateTime)
 Subtracts business days to an existing DateTime instance.
 
-**Kind**: global function  
-**Extends**: <code>DateTime</code>  
+**Kind**: instance method of [<code>DateTime</code>](#DateTime)  
+**Extends**: [<code>DateTime</code>](#DateTime)  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | [days] | <code>number</code> | <code>1</code> | The number of business days to subtract. |
+
+<a name="getEasterMonthAndDay"></a>
+
+## getEasterMonthAndDay(year) ⇒ <code>Array</code>
+Returns the month and day of Easter for a given year.
+
+**Kind**: global function  
+**Returns**: <code>Array</code> - Returns month and day via `[month, day]`.  
+
+| Param | Type |
+| --- | --- |
+| year | <code>number</code> | 
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,6 @@
+// TODO fix jsdoc generation of this. Something is marked right.
 /**
- * @module holidayHelpers
+ * @alias DateTime.prototype.availableHolidayHelpers
  */
 
 /*

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,6 @@
+/**
+ * @augments DateTime
+ */
 let DateTime;
 
 /* istanbul ignore next */
@@ -21,7 +24,7 @@ import {
 /**
  * All built-in holiday matchers.
  * @augments DateTime
- * @var {Object} availableHolidayMatchers
+ * @member {Object}
  * @property {function} isNewYearsDay - A provided holiday matcher.
  * @property {function} isMLKDay - A provided holiday matcher.
  * @property {function} isEasterDay - A provided holiday matcher.
@@ -37,16 +40,14 @@ DateTime.prototype.availableHolidayMatchers = holidays;
 /**
  * Exposes all available holiday helpers to a DateTime instance.
  * @augments DateTime
- * @var {Object} availableHolidayHelpers
+ * @member {Object}
  * @property {function} getEasterMonthAndDay - A provided holiday helper function that can be helpful for custom holiday matchers.
- * @see [holidayHelpers]{@link #module_holidayHelpers}
  */
 DateTime.prototype.availableHolidayHelpers = helpers;
 
 /**
  * Sets up business days and holiday matchers globally for all DateTime instances.
  * @augments DateTime
- * @method setupBusiness
  * @param {Array<number>} [businessDays=DEFAULT_BUSINESS_DAYS] - The working business days for the business.
  * @param {Array<function>} [holidayMatchers=DEFAULT_HOLIDAY_MATCHERS] - The holiday matchers used to check if a particular day is a holiday for the business.
  */
@@ -54,7 +55,7 @@ DateTime.prototype.setupBusiness = function({
   businessDays = DEFAULT_BUSINESS_DAYS,
   holidayMatchers = DEFAULT_HOLIDAY_MATCHERS,
 } = {}) {
-  /**
+  /*
    * luxon does not clone custom properties so to maintain
    * config access across new instances we add our config
    * to the chain as a workaround
@@ -70,7 +71,6 @@ DateTime.prototype.setupBusiness = function({
 /**
  * Clears business setup globally from all DateTime instances.
  * @augments DateTime
- * @method clearBusinessSetup
  */
 DateTime.prototype.clearBusinessSetup = function() {
   delete DateTime.prototype.businessDays;
@@ -80,7 +80,6 @@ DateTime.prototype.clearBusinessSetup = function() {
 /**
  * Checks if DateTime instance is a holiday by checking against all holiday matchers.
  * @augments DateTime
- * @method isHoliday
  * @param {...*} [args] - Any additional arguments to pass through to each holiday matcher.
  * @returns {boolean}
  */
@@ -97,7 +96,6 @@ DateTime.prototype.isHoliday = function(...args) {
 /**
  * Checks if DateTime instance is a business day.
  * @augments DateTime
- * @method isBusinessDay
  * @returns {boolean}
  */
 DateTime.prototype.isBusinessDay = function() {
@@ -109,7 +107,6 @@ DateTime.prototype.isBusinessDay = function() {
 /**
  * Adds business days to an existing DateTime instance.
  * @augments DateTime
- * @method plusBusiness
  * @param {number} [days=1] - The number of business days to add.
  * @returns {DateTime}
  */
@@ -141,7 +138,6 @@ DateTime.prototype.plusBusiness = function({ days = ONE_DAY } = {}) {
 /**
  * Subtracts business days to an existing DateTime instance.
  * @augments DateTime
- * @method minusBusiness
  * @param {number} [days=1] - The number of business days to subtract.
  * @returns {DateTime}
  */


### PR DESCRIPTION
This updates the docs to clarify that `DateTime` from this plugin is a global variable that extends `DateTime` from `luxon`.

--
For some reason having a difficult time generating the correct jsDoc snippets for https://github.com/amaidah/luxon-business-days/pull/39/files#diff-49ba0c85360693b8e89ae0e0428284a55db749f08f2b9993d26910def646e02fR1 and leaving it as a `TODO` for now

