### PR TITLE
Add businessDiff method

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,14 @@ dt.isHoliday('middle-america', {some: 'stuff'});
 </dd>
 </dl>
 
+## Typedefs
+
+<dl>
+<dt><a href="#BusinessDiffConfig">BusinessDiffConfig</a> ⇒ <code>number</code></dt>
+<dd><p>Returns the difference in business days.  Set relative to true if you need to support past dates.</p>
+</dd>
+</dl>
+
 <a name="DateTime"></a>
 
 ## DateTime ⇐ [<code>DateTime</code>](#DateTime)
@@ -264,7 +272,6 @@ dt.isHoliday('middle-america', {some: 'stuff'});
     * [.isBusinessDay()](#DateTime+isBusinessDay) ⇒ <code>boolean</code>
     * [.plusBusiness([days])](#DateTime+plusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
     * [.minusBusiness([days])](#DateTime+minusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
-    * [.businessDiff(targetDate, relative)](#DateTime+businessDiff) ⇒ <code>number</code>
 
 <a name="DateTime+availableHolidayMatchers"></a>
 
@@ -363,18 +370,6 @@ Subtracts business days to an existing DateTime instance.
 | --- | --- | --- | --- |
 | [days] | <code>number</code> | <code>1</code> | The number of business days to subtract. |
 
-<a name="DateTime+businessDiff"></a>
-
-### dateTime.businessDiff(targetDate, relative) ⇒ <code>number</code>
-Returns the difference in business days.  Set relative to true if you need to support past dates.
-
-**Kind**: instance method of [<code>DateTime</code>](#DateTime)  
-
-| Param | Type |
-| --- | --- |
-| targetDate | [<code>DateTime</code>](#DateTime) | 
-| relative | <code>boolean</code> | 
-
 <a name="getEasterMonthAndDay"></a>
 
 ## getEasterMonthAndDay(year) ⇒ <code>Array.&lt;number&gt;</code>
@@ -386,4 +381,23 @@ Returns the month and day of Easter for a given year.
 | Param | Type |
 | --- | --- |
 | year | <code>number</code> | 
+
+<a name="BusinessDiffConfig"></a>
+
+## BusinessDiffConfig ⇒ <code>number</code>
+Returns the difference in business days.  Set relative to true if you need to support past dates.
+
+**Kind**: global typedef  
+
+| Param | Type |
+| --- | --- |
+| targetDate | [<code>DateTime</code>](#DateTime) | 
+| config | [<code>BusinessDiffConfig</code>](#BusinessDiffConfig) | 
+
+**Properties**
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| [includeEndDate] | <code>boolean</code> | <code>false</code> | includeEndDate |
+| [relative] | <code>boolean</code> | <code>false</code> | relative |
 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ Subtracts business days to an existing DateTime instance.
 <a name="DateTime+businessDiff"></a>
 
 ### dateTime.businessDiff(targetDate, config) ⇒ <code>number</code>
-Returns the difference in business days.  Set relative to true if you need to support past dates.
+Returns the difference in business days.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
 

--- a/README.md
+++ b/README.md
@@ -402,6 +402,6 @@ Returns the month and day of Easter for a given year.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| [includeEndDate] | <code>boolean</code> | <code>false</code> | includeEndDate |
-| [relative] | <code>boolean</code> | <code>false</code> | relative |
+| [includeEndDate] | <code>boolean</code> | <code>false</code> | include the end date in the calculation |
+| [relative] | <code>boolean</code> | <code>false</code> | signs the return value as negative if end date is in the past |
 

--- a/README.md
+++ b/README.md
@@ -58,19 +58,19 @@ https://cdn.jsdelivr.net/npm/luxon-business-days@2.7.0/dist/index.js
 ```
 
 ```html
-<head> 
+<head>
   <script src="https://cdn.jsdelivr.net/npm/luxon@1.25.0/build/global/luxon.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/luxon-business-days/dist/index.js"></script>
-</head> 
+</head>
 
-<body> 
+<body>
   <script>
     let dt = luxon.DateTime.local();
     const nextBizDay = dt.plusBusiness();
 
     console.log(nextBizDay.toLocaleString());
   </script>
-</body> 
+</body>
 ```
 
 ## Config
@@ -166,7 +166,7 @@ const myHolidays = [
 ];
 
 dt.setupBusiness({ holidayMatchers: myHolidays });
-// Congrats, now your business will consider New Years, 
+// Congrats, now your business will consider New Years,
 // Christmas, and the two Kobe days as holidays.
 ```
 
@@ -185,7 +185,7 @@ let dt = DateTime.local(2019, 7, 3);
 dt = dt.plusBusiness(); // 7/5/19 - Friday
 dt = dt.plusBusiness({ days: 2 }); // 7/9/19 - Tuesday (Skipped through Saturday/Sunday)
 dt = dt.minusBusiness({ days: 2 }); // back to 7/5/19
-dt = dt.minusBusiness({ days: -2 }) // back to 7/9/19
+dt = dt.minusBusiness({ days: -2 }); // back to 7/9/19
 dt = dt.plusBusiness({ days: -2 }); // back to 7/5/19
 
 // Now do what you normally would with a DateTime instance.
@@ -206,7 +206,7 @@ import { DateTime } from 'luxon-business-days';
  */
 const someCustomRegionalMatcher = (inst, region, someStuff) => {
   // does some matching based on region and data in someStuff
-}
+};
 
 /**
  * @param {DateTime} - An instance of DateTime.
@@ -214,23 +214,20 @@ const someCustomRegionalMatcher = (inst, region, someStuff) => {
  */
 const anotherCustomMatcher = inst => {
   // does some matching, but doesn't need additional info
-}
+};
 
 let dt = DateTime.local();
-const myHolidays = [
-  someCustomRegionalMatcher,
-  anotherCustomMatcher,
-];
+const myHolidays = [someCustomRegionalMatcher, anotherCustomMatcher];
 
 dt.setupBusiness({ holidayMatchers: myHolidays });
 
 // Pass any additional argument to all your matchers
-dt.isHoliday('middle-america', {some: 'stuff'});
+dt.isHoliday('middle-america', { some: 'stuff' });
 ```
 
 ## Examples
 
-* [Display a range of delivery dates for a shipment](https://codesandbox.io/s/luxon-business-days-range-example-tmb1d).
+- [Display a range of delivery dates for a shipment](https://codesandbox.io/s/luxon-business-days-range-example-tmb1d).
 
 ## API
 
@@ -252,77 +249,82 @@ dt.isHoliday('middle-america', {some: 'stuff'});
 ## Typedefs
 
 <dl>
-<dt><a href="#BusinessDiffConfig">BusinessDiffConfig</a></dt>
+<dt><a href="#diffBusinessConfig">diffBusinessConfig</a></dt>
 <dd></dd>
 </dl>
 
 <a name="DateTime"></a>
 
 ## DateTime ⇐ [<code>DateTime</code>](#DateTime)
-**Kind**: global variable  
-**Extends**: [<code>DateTime</code>](#DateTime)  
 
-* [DateTime](#DateTime) ⇐ [<code>DateTime</code>](#DateTime)
-    * [.availableHolidayMatchers](#DateTime+availableHolidayMatchers) : <code>Object</code>
-    * [.availableHolidayHelpers](#DateTime+availableHolidayHelpers) : <code>Object</code>
-    * [.setupBusiness([businessDays], [holidayMatchers])](#DateTime+setupBusiness) ⇐ [<code>DateTime</code>](#DateTime)
-    * [.clearBusinessSetup()](#DateTime+clearBusinessSetup) ⇐ [<code>DateTime</code>](#DateTime)
-    * [.isHoliday([...args])](#DateTime+isHoliday) ⇒ <code>boolean</code>
-    * [.isBusinessDay()](#DateTime+isBusinessDay) ⇒ <code>boolean</code>
-    * [.plusBusiness([days])](#DateTime+plusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
-    * [.minusBusiness([days])](#DateTime+minusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
-    * [.businessDiff(targetDate, config)](#DateTime+businessDiff) ⇒ <code>number</code>
+**Kind**: global variable  
+**Extends**: [<code>DateTime</code>](#DateTime)
+
+- [DateTime](#DateTime) ⇐ [<code>DateTime</code>](#DateTime)
+  - [.availableHolidayMatchers](#DateTime+availableHolidayMatchers) : <code>Object</code>
+  - [.availableHolidayHelpers](#DateTime+availableHolidayHelpers) : <code>Object</code>
+  - [.setupBusiness([businessDays], [holidayMatchers])](#DateTime+setupBusiness) ⇐ [<code>DateTime</code>](#DateTime)
+  - [.clearBusinessSetup()](#DateTime+clearBusinessSetup) ⇐ [<code>DateTime</code>](#DateTime)
+  - [.isHoliday([...args])](#DateTime+isHoliday) ⇒ <code>boolean</code>
+  - [.isBusinessDay()](#DateTime+isBusinessDay) ⇒ <code>boolean</code>
+  - [.plusBusiness([days])](#DateTime+plusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
+  - [.minusBusiness([days])](#DateTime+minusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
+  - [.diffBusiness(targetDate, config)](#DateTime+diffBusiness) ⇒ <code>number</code>
 
 <a name="DateTime+availableHolidayMatchers"></a>
 
 ### dateTime.availableHolidayMatchers : <code>Object</code>
+
 All built-in holiday matchers.
 
 **Kind**: instance property of [<code>DateTime</code>](#DateTime)  
 **Extends**: [<code>DateTime</code>](#DateTime)  
 **Properties**
 
-| Name | Type | Description |
-| --- | --- | --- |
-| isNewYearsDay | <code>function</code> | A provided holiday matcher. |
-| isMLKDay | <code>function</code> | A provided holiday matcher. |
-| isEasterDay | <code>function</code> | A provided holiday matcher. |
-| isMemorialDay | <code>function</code> | A provided holiday matcher. |
+| Name              | Type                  | Description                 |
+| ----------------- | --------------------- | --------------------------- |
+| isNewYearsDay     | <code>function</code> | A provided holiday matcher. |
+| isMLKDay          | <code>function</code> | A provided holiday matcher. |
+| isEasterDay       | <code>function</code> | A provided holiday matcher. |
+| isMemorialDay     | <code>function</code> | A provided holiday matcher. |
 | isIndependanceDay | <code>function</code> | A provided holiday matcher. |
-| isLaborDay | <code>function</code> | A provided holiday matcher. |
-| isColumbusDay | <code>function</code> | A provided holiday matcher. |
+| isLaborDay        | <code>function</code> | A provided holiday matcher. |
+| isColumbusDay     | <code>function</code> | A provided holiday matcher. |
 | isThanksgivingDay | <code>function</code> | A provided holiday matcher. |
-| isChristmasDay | <code>function</code> | A provided holiday matcher. |
+| isChristmasDay    | <code>function</code> | A provided holiday matcher. |
 
 <a name="DateTime+availableHolidayHelpers"></a>
 
 ### dateTime.availableHolidayHelpers : <code>Object</code>
+
 Exposes all available holiday helpers to a DateTime instance.
 
 **Kind**: instance property of [<code>DateTime</code>](#DateTime)  
 **Extends**: [<code>DateTime</code>](#DateTime)  
 **Properties**
 
-| Name | Type | Description |
-| --- | --- | --- |
+| Name                 | Type                  | Description                                                                         |
+| -------------------- | --------------------- | ----------------------------------------------------------------------------------- |
 | getEasterMonthAndDay | <code>function</code> | A provided holiday helper function that can be helpful for custom holiday matchers. |
 
 <a name="DateTime+setupBusiness"></a>
 
 ### dateTime.setupBusiness([businessDays], [holidayMatchers]) ⇐ [<code>DateTime</code>](#DateTime)
+
 Sets up business days and holiday matchers globally for all DateTime instances.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
-**Extends**: [<code>DateTime</code>](#DateTime)  
+**Extends**: [<code>DateTime</code>](#DateTime)
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| [businessDays] | <code>Array.&lt;number&gt;</code> | <code>DEFAULT_BUSINESS_DAYS</code> | The working business days for the business. |
+| Param             | Type                                  | Default                               | Description                                                                           |
+| ----------------- | ------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------- |
+| [businessDays]    | <code>Array.&lt;number&gt;</code>     | <code>DEFAULT_BUSINESS_DAYS</code>    | The working business days for the business.                                           |
 | [holidayMatchers] | <code>Array.&lt;function()&gt;</code> | <code>DEFAULT_HOLIDAY_MATCHERS</code> | The holiday matchers used to check if a particular day is a holiday for the business. |
 
 <a name="DateTime+clearBusinessSetup"></a>
 
 ### dateTime.clearBusinessSetup() ⇐ [<code>DateTime</code>](#DateTime)
+
 Clears business setup globally from all DateTime instances.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
@@ -330,18 +332,20 @@ Clears business setup globally from all DateTime instances.
 <a name="DateTime+isHoliday"></a>
 
 ### dateTime.isHoliday([...args]) ⇒ <code>boolean</code>
+
 Checks if DateTime instance is a holiday by checking against all holiday matchers.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
-**Extends**: [<code>DateTime</code>](#DateTime)  
+**Extends**: [<code>DateTime</code>](#DateTime)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param     | Type            | Description                                                       |
+| --------- | --------------- | ----------------------------------------------------------------- |
 | [...args] | <code>\*</code> | Any additional arguments to pass through to each holiday matcher. |
 
 <a name="DateTime+isBusinessDay"></a>
 
 ### dateTime.isBusinessDay() ⇒ <code>boolean</code>
+
 Checks if DateTime instance is a business day.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
@@ -349,59 +353,63 @@ Checks if DateTime instance is a business day.
 <a name="DateTime+plusBusiness"></a>
 
 ### dateTime.plusBusiness([days]) ⇒ [<code>DateTime</code>](#DateTime)
+
 Adds business days to an existing DateTime instance.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
-**Extends**: [<code>DateTime</code>](#DateTime)  
+**Extends**: [<code>DateTime</code>](#DateTime)
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
+| Param  | Type                | Default        | Description                         |
+| ------ | ------------------- | -------------- | ----------------------------------- |
 | [days] | <code>number</code> | <code>1</code> | The number of business days to add. |
 
 <a name="DateTime+minusBusiness"></a>
 
 ### dateTime.minusBusiness([days]) ⇒ [<code>DateTime</code>](#DateTime)
+
 Subtracts business days to an existing DateTime instance.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
-**Extends**: [<code>DateTime</code>](#DateTime)  
+**Extends**: [<code>DateTime</code>](#DateTime)
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
+| Param  | Type                | Default        | Description                              |
+| ------ | ------------------- | -------------- | ---------------------------------------- |
 | [days] | <code>number</code> | <code>1</code> | The number of business days to subtract. |
 
-<a name="DateTime+businessDiff"></a>
+<a name="DateTime+diffBusiness"></a>
 
-### dateTime.businessDiff(targetDate, config) ⇒ <code>number</code>
+### dateTime.diffBusiness(targetDate, config) ⇒ <code>number</code>
+
 Returns the difference in business days.
 
-**Kind**: instance method of [<code>DateTime</code>](#DateTime)  
+**Kind**: instance method of [<code>DateTime</code>](#DateTime)
 
-| Param | Type |
-| --- | --- |
-| targetDate | [<code>DateTime</code>](#DateTime) | 
-| config | [<code>BusinessDiffConfig</code>](#BusinessDiffConfig) | 
+| Param      | Type                                                   |
+| ---------- | ------------------------------------------------------ |
+| targetDate | [<code>DateTime</code>](#DateTime)                     |
+| config     | [<code>diffBusinessConfig</code>](#diffBusinessConfig) |
 
 <a name="getEasterMonthAndDay"></a>
 
 ## getEasterMonthAndDay(year) ⇒ <code>Array.&lt;number&gt;</code>
+
 Returns the month and day of Easter for a given year.
 
 **Kind**: global function  
-**Returns**: <code>Array.&lt;number&gt;</code> - Returns month and day via `[month, day]`.  
+**Returns**: <code>Array.&lt;number&gt;</code> - Returns month and day via `[month, day]`.
 
-| Param | Type |
-| --- | --- |
-| year | <code>number</code> | 
+| Param | Type                |
+| ----- | ------------------- |
+| year  | <code>number</code> |
 
-<a name="BusinessDiffConfig"></a>
+<a name="diffBusinessConfig"></a>
 
-## BusinessDiffConfig
+## diffBusinessConfig
+
 **Kind**: global typedef  
 **Properties**
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| [includeEndDate] | <code>boolean</code> | <code>false</code> | include the end date in the calculation |
-| [relative] | <code>boolean</code> | <code>false</code> | signs the return value as negative if end date is in the past |
-
+| Name             | Type                 | Default            | Description                                                   |
+| ---------------- | -------------------- | ------------------ | ------------------------------------------------------------- |
+| [includeEndDate] | <code>boolean</code> | <code>false</code> | include the end date in the calculation                       |
+| [relative]       | <code>boolean</code> | <code>false</code> | signs the return value as negative if end date is in the past |

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ dt.isHoliday('middle-america', {some: 'stuff'});
     * [.isBusinessDay()](#DateTime+isBusinessDay) ⇒ <code>boolean</code>
     * [.plusBusiness([days])](#DateTime+plusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
     * [.minusBusiness([days])](#DateTime+minusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
+    * [.businessDiff(targetDate, relative)](#DateTime+businessDiff) ⇒ <code>number</code>
 
 <a name="DateTime+availableHolidayMatchers"></a>
 
@@ -361,6 +362,18 @@ Subtracts business days to an existing DateTime instance.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | [days] | <code>number</code> | <code>1</code> | The number of business days to subtract. |
+
+<a name="DateTime+businessDiff"></a>
+
+### dateTime.businessDiff(targetDate, relative) ⇒ <code>number</code>
+Returns the difference in business days.  Set relative to true if you need to support past dates.
+
+**Kind**: instance method of [<code>DateTime</code>](#DateTime)  
+
+| Param | Type |
+| --- | --- |
+| targetDate | [<code>DateTime</code>](#DateTime) | 
+| relative | <code>boolean</code> | 
 
 <a name="getEasterMonthAndDay"></a>
 

--- a/README.md
+++ b/README.md
@@ -252,9 +252,8 @@ dt.isHoliday('middle-america', {some: 'stuff'});
 ## Typedefs
 
 <dl>
-<dt><a href="#BusinessDiffConfig">BusinessDiffConfig</a> ⇒ <code>number</code></dt>
-<dd><p>Returns the difference in business days.  Set relative to true if you need to support past dates.</p>
-</dd>
+<dt><a href="#BusinessDiffConfig">BusinessDiffConfig</a></dt>
+<dd></dd>
 </dl>
 
 <a name="DateTime"></a>
@@ -272,6 +271,7 @@ dt.isHoliday('middle-america', {some: 'stuff'});
     * [.isBusinessDay()](#DateTime+isBusinessDay) ⇒ <code>boolean</code>
     * [.plusBusiness([days])](#DateTime+plusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
     * [.minusBusiness([days])](#DateTime+minusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
+    * [.businessDiff(targetDate, config)](#DateTime+businessDiff) ⇒ <code>number</code>
 
 <a name="DateTime+availableHolidayMatchers"></a>
 
@@ -370,6 +370,18 @@ Subtracts business days to an existing DateTime instance.
 | --- | --- | --- | --- |
 | [days] | <code>number</code> | <code>1</code> | The number of business days to subtract. |
 
+<a name="DateTime+businessDiff"></a>
+
+### dateTime.businessDiff(targetDate, config) ⇒ <code>number</code>
+Returns the difference in business days.  Set relative to true if you need to support past dates.
+
+**Kind**: instance method of [<code>DateTime</code>](#DateTime)  
+
+| Param | Type |
+| --- | --- |
+| targetDate | [<code>DateTime</code>](#DateTime) | 
+| config | [<code>BusinessDiffConfig</code>](#BusinessDiffConfig) | 
+
 <a name="getEasterMonthAndDay"></a>
 
 ## getEasterMonthAndDay(year) ⇒ <code>Array.&lt;number&gt;</code>
@@ -384,16 +396,8 @@ Returns the month and day of Easter for a given year.
 
 <a name="BusinessDiffConfig"></a>
 
-## BusinessDiffConfig ⇒ <code>number</code>
-Returns the difference in business days.  Set relative to true if you need to support past dates.
-
+## BusinessDiffConfig
 **Kind**: global typedef  
-
-| Param | Type |
-| --- | --- |
-| targetDate | [<code>DateTime</code>](#DateTime) | 
-| config | [<code>BusinessDiffConfig</code>](#BusinessDiffConfig) | 
-
 **Properties**
 
 | Name | Type | Default | Description |

--- a/README.md
+++ b/README.md
@@ -58,19 +58,19 @@ https://cdn.jsdelivr.net/npm/luxon-business-days@2.7.0/dist/index.js
 ```
 
 ```html
-<head>
+<head> 
   <script src="https://cdn.jsdelivr.net/npm/luxon@1.25.0/build/global/luxon.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/luxon-business-days/dist/index.js"></script>
-</head>
+</head> 
 
-<body>
+<body> 
   <script>
     let dt = luxon.DateTime.local();
     const nextBizDay = dt.plusBusiness();
 
     console.log(nextBizDay.toLocaleString());
   </script>
-</body>
+</body> 
 ```
 
 ## Config
@@ -166,7 +166,7 @@ const myHolidays = [
 ];
 
 dt.setupBusiness({ holidayMatchers: myHolidays });
-// Congrats, now your business will consider New Years,
+// Congrats, now your business will consider New Years, 
 // Christmas, and the two Kobe days as holidays.
 ```
 
@@ -185,7 +185,7 @@ let dt = DateTime.local(2019, 7, 3);
 dt = dt.plusBusiness(); // 7/5/19 - Friday
 dt = dt.plusBusiness({ days: 2 }); // 7/9/19 - Tuesday (Skipped through Saturday/Sunday)
 dt = dt.minusBusiness({ days: 2 }); // back to 7/5/19
-dt = dt.minusBusiness({ days: -2 }); // back to 7/9/19
+dt = dt.minusBusiness({ days: -2 }) // back to 7/9/19
 dt = dt.plusBusiness({ days: -2 }); // back to 7/5/19
 
 // Now do what you normally would with a DateTime instance.
@@ -206,7 +206,7 @@ import { DateTime } from 'luxon-business-days';
  */
 const someCustomRegionalMatcher = (inst, region, someStuff) => {
   // does some matching based on region and data in someStuff
-};
+}
 
 /**
  * @param {DateTime} - An instance of DateTime.
@@ -214,20 +214,23 @@ const someCustomRegionalMatcher = (inst, region, someStuff) => {
  */
 const anotherCustomMatcher = inst => {
   // does some matching, but doesn't need additional info
-};
+}
 
 let dt = DateTime.local();
-const myHolidays = [someCustomRegionalMatcher, anotherCustomMatcher];
+const myHolidays = [
+  someCustomRegionalMatcher,
+  anotherCustomMatcher,
+];
 
 dt.setupBusiness({ holidayMatchers: myHolidays });
 
 // Pass any additional argument to all your matchers
-dt.isHoliday('middle-america', { some: 'stuff' });
+dt.isHoliday('middle-america', {some: 'stuff'});
 ```
 
 ## Examples
 
-- [Display a range of delivery dates for a shipment](https://codesandbox.io/s/luxon-business-days-range-example-tmb1d).
+* [Display a range of delivery dates for a shipment](https://codesandbox.io/s/luxon-business-days-range-example-tmb1d).
 
 ## API
 
@@ -249,82 +252,77 @@ dt.isHoliday('middle-america', { some: 'stuff' });
 ## Typedefs
 
 <dl>
-<dt><a href="#diffBusinessConfig">diffBusinessConfig</a></dt>
+<dt><a href="#DiffBusinessConfig">DiffBusinessConfig</a></dt>
 <dd></dd>
 </dl>
 
 <a name="DateTime"></a>
 
 ## DateTime ⇐ [<code>DateTime</code>](#DateTime)
-
 **Kind**: global variable  
-**Extends**: [<code>DateTime</code>](#DateTime)
+**Extends**: [<code>DateTime</code>](#DateTime)  
 
-- [DateTime](#DateTime) ⇐ [<code>DateTime</code>](#DateTime)
-  - [.availableHolidayMatchers](#DateTime+availableHolidayMatchers) : <code>Object</code>
-  - [.availableHolidayHelpers](#DateTime+availableHolidayHelpers) : <code>Object</code>
-  - [.setupBusiness([businessDays], [holidayMatchers])](#DateTime+setupBusiness) ⇐ [<code>DateTime</code>](#DateTime)
-  - [.clearBusinessSetup()](#DateTime+clearBusinessSetup) ⇐ [<code>DateTime</code>](#DateTime)
-  - [.isHoliday([...args])](#DateTime+isHoliday) ⇒ <code>boolean</code>
-  - [.isBusinessDay()](#DateTime+isBusinessDay) ⇒ <code>boolean</code>
-  - [.plusBusiness([days])](#DateTime+plusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
-  - [.minusBusiness([days])](#DateTime+minusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
-  - [.diffBusiness(targetDate, config)](#DateTime+diffBusiness) ⇒ <code>number</code>
+* [DateTime](#DateTime) ⇐ [<code>DateTime</code>](#DateTime)
+    * [.availableHolidayMatchers](#DateTime+availableHolidayMatchers) : <code>Object</code>
+    * [.availableHolidayHelpers](#DateTime+availableHolidayHelpers) : <code>Object</code>
+    * [.setupBusiness([businessDays], [holidayMatchers])](#DateTime+setupBusiness) ⇐ [<code>DateTime</code>](#DateTime)
+    * [.clearBusinessSetup()](#DateTime+clearBusinessSetup) ⇐ [<code>DateTime</code>](#DateTime)
+    * [.isHoliday([...args])](#DateTime+isHoliday) ⇒ <code>boolean</code>
+    * [.isBusinessDay()](#DateTime+isBusinessDay) ⇒ <code>boolean</code>
+    * [.plusBusiness([days])](#DateTime+plusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
+    * [.minusBusiness([days])](#DateTime+minusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
+    * [.diffBusiness(targetDate, config)](#DateTime+diffBusiness) ⇒ <code>number</code>
 
 <a name="DateTime+availableHolidayMatchers"></a>
 
 ### dateTime.availableHolidayMatchers : <code>Object</code>
-
 All built-in holiday matchers.
 
 **Kind**: instance property of [<code>DateTime</code>](#DateTime)  
 **Extends**: [<code>DateTime</code>](#DateTime)  
 **Properties**
 
-| Name              | Type                  | Description                 |
-| ----------------- | --------------------- | --------------------------- |
-| isNewYearsDay     | <code>function</code> | A provided holiday matcher. |
-| isMLKDay          | <code>function</code> | A provided holiday matcher. |
-| isEasterDay       | <code>function</code> | A provided holiday matcher. |
-| isMemorialDay     | <code>function</code> | A provided holiday matcher. |
+| Name | Type | Description |
+| --- | --- | --- |
+| isNewYearsDay | <code>function</code> | A provided holiday matcher. |
+| isMLKDay | <code>function</code> | A provided holiday matcher. |
+| isEasterDay | <code>function</code> | A provided holiday matcher. |
+| isMemorialDay | <code>function</code> | A provided holiday matcher. |
 | isIndependanceDay | <code>function</code> | A provided holiday matcher. |
-| isLaborDay        | <code>function</code> | A provided holiday matcher. |
-| isColumbusDay     | <code>function</code> | A provided holiday matcher. |
+| isLaborDay | <code>function</code> | A provided holiday matcher. |
+| isColumbusDay | <code>function</code> | A provided holiday matcher. |
 | isThanksgivingDay | <code>function</code> | A provided holiday matcher. |
-| isChristmasDay    | <code>function</code> | A provided holiday matcher. |
+| isChristmasDay | <code>function</code> | A provided holiday matcher. |
 
 <a name="DateTime+availableHolidayHelpers"></a>
 
 ### dateTime.availableHolidayHelpers : <code>Object</code>
-
 Exposes all available holiday helpers to a DateTime instance.
 
 **Kind**: instance property of [<code>DateTime</code>](#DateTime)  
 **Extends**: [<code>DateTime</code>](#DateTime)  
 **Properties**
 
-| Name                 | Type                  | Description                                                                         |
-| -------------------- | --------------------- | ----------------------------------------------------------------------------------- |
+| Name | Type | Description |
+| --- | --- | --- |
 | getEasterMonthAndDay | <code>function</code> | A provided holiday helper function that can be helpful for custom holiday matchers. |
 
 <a name="DateTime+setupBusiness"></a>
 
 ### dateTime.setupBusiness([businessDays], [holidayMatchers]) ⇐ [<code>DateTime</code>](#DateTime)
-
 Sets up business days and holiday matchers globally for all DateTime instances.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
-**Extends**: [<code>DateTime</code>](#DateTime)
+**Extends**: [<code>DateTime</code>](#DateTime)  
 
-| Param             | Type                                  | Default                               | Description                                                                           |
-| ----------------- | ------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------- |
-| [businessDays]    | <code>Array.&lt;number&gt;</code>     | <code>DEFAULT_BUSINESS_DAYS</code>    | The working business days for the business.                                           |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [businessDays] | <code>Array.&lt;number&gt;</code> | <code>DEFAULT_BUSINESS_DAYS</code> | The working business days for the business. |
 | [holidayMatchers] | <code>Array.&lt;function()&gt;</code> | <code>DEFAULT_HOLIDAY_MATCHERS</code> | The holiday matchers used to check if a particular day is a holiday for the business. |
 
 <a name="DateTime+clearBusinessSetup"></a>
 
 ### dateTime.clearBusinessSetup() ⇐ [<code>DateTime</code>](#DateTime)
-
 Clears business setup globally from all DateTime instances.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
@@ -332,20 +330,18 @@ Clears business setup globally from all DateTime instances.
 <a name="DateTime+isHoliday"></a>
 
 ### dateTime.isHoliday([...args]) ⇒ <code>boolean</code>
-
 Checks if DateTime instance is a holiday by checking against all holiday matchers.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
-**Extends**: [<code>DateTime</code>](#DateTime)
+**Extends**: [<code>DateTime</code>](#DateTime)  
 
-| Param     | Type            | Description                                                       |
-| --------- | --------------- | ----------------------------------------------------------------- |
+| Param | Type | Description |
+| --- | --- | --- |
 | [...args] | <code>\*</code> | Any additional arguments to pass through to each holiday matcher. |
 
 <a name="DateTime+isBusinessDay"></a>
 
 ### dateTime.isBusinessDay() ⇒ <code>boolean</code>
-
 Checks if DateTime instance is a business day.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
@@ -353,63 +349,59 @@ Checks if DateTime instance is a business day.
 <a name="DateTime+plusBusiness"></a>
 
 ### dateTime.plusBusiness([days]) ⇒ [<code>DateTime</code>](#DateTime)
-
 Adds business days to an existing DateTime instance.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
-**Extends**: [<code>DateTime</code>](#DateTime)
+**Extends**: [<code>DateTime</code>](#DateTime)  
 
-| Param  | Type                | Default        | Description                         |
-| ------ | ------------------- | -------------- | ----------------------------------- |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
 | [days] | <code>number</code> | <code>1</code> | The number of business days to add. |
 
 <a name="DateTime+minusBusiness"></a>
 
 ### dateTime.minusBusiness([days]) ⇒ [<code>DateTime</code>](#DateTime)
-
 Subtracts business days to an existing DateTime instance.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
-**Extends**: [<code>DateTime</code>](#DateTime)
+**Extends**: [<code>DateTime</code>](#DateTime)  
 
-| Param  | Type                | Default        | Description                              |
-| ------ | ------------------- | -------------- | ---------------------------------------- |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
 | [days] | <code>number</code> | <code>1</code> | The number of business days to subtract. |
 
 <a name="DateTime+diffBusiness"></a>
 
 ### dateTime.diffBusiness(targetDate, config) ⇒ <code>number</code>
-
 Returns the difference in business days.
 
-**Kind**: instance method of [<code>DateTime</code>](#DateTime)
+**Kind**: instance method of [<code>DateTime</code>](#DateTime)  
 
-| Param      | Type                                                   |
-| ---------- | ------------------------------------------------------ |
-| targetDate | [<code>DateTime</code>](#DateTime)                     |
-| config     | [<code>diffBusinessConfig</code>](#diffBusinessConfig) |
+| Param | Type |
+| --- | --- |
+| targetDate | [<code>DateTime</code>](#DateTime) | 
+| config | [<code>DiffBusinessConfig</code>](#DiffBusinessConfig) | 
 
 <a name="getEasterMonthAndDay"></a>
 
 ## getEasterMonthAndDay(year) ⇒ <code>Array.&lt;number&gt;</code>
-
 Returns the month and day of Easter for a given year.
 
 **Kind**: global function  
-**Returns**: <code>Array.&lt;number&gt;</code> - Returns month and day via `[month, day]`.
+**Returns**: <code>Array.&lt;number&gt;</code> - Returns month and day via `[month, day]`.  
 
-| Param | Type                |
-| ----- | ------------------- |
-| year  | <code>number</code> |
+| Param | Type |
+| --- | --- |
+| year | <code>number</code> | 
 
-<a name="diffBusinessConfig"></a>
+<a name="DiffBusinessConfig"></a>
 
-## diffBusinessConfig
-
+## DiffBusinessConfig
 **Kind**: global typedef  
 **Properties**
 
-| Name             | Type                 | Default            | Description                                                   |
-| ---------------- | -------------------- | ------------------ | ------------------------------------------------------------- |
-| [includeEndDate] | <code>boolean</code> | <code>false</code> | include the end date in the calculation                       |
-| [relative]       | <code>boolean</code> | <code>false</code> | signs the return value as negative if end date is in the past |
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| [includeEndDate] | <code>boolean</code> | <code>false</code> | include the end date in the calculation |
+| [relative] | <code>boolean</code> | <code>false</code> | signs the return value as negative if end date is in the past |
+

--- a/src/index.js
+++ b/src/index.js
@@ -147,7 +147,7 @@ DateTime.prototype.minusBusiness = function({ days = ONE_DAY } = {}) {
 };
 
 /**
- * @typedef BusinessDiffConfig
+ * @typedef DiffBusinessConfig
  * @property {boolean} [includeEndDate=false] - include the end date in the calculation
  * @property {boolean} [relative=false] - signs the return value as negative if end date is in the past
  */
@@ -155,7 +155,7 @@ DateTime.prototype.minusBusiness = function({ days = ONE_DAY } = {}) {
 /**
  * Returns the difference in business days.
  * @param {DateTime} targetDate
- * @param {BusinessDiffConfig} config
+ * @param {DiffBusinessConfig} config
  * @returns {number}
  */
 DateTime.prototype.diffBusiness = function(

--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ DateTime.prototype.minusBusiness = function({ days = ONE_DAY } = {}) {
  * @param {BusinessDiffConfig} config
  * @returns {number}
  */
-DateTime.prototype.businessDiff = function(
+DateTime.prototype.diffBusiness = function(
   targetDate,
   { includeEndDate = false, relative = false } = {}
 ) {

--- a/src/index.js
+++ b/src/index.js
@@ -166,7 +166,7 @@ DateTime.prototype.businessDiff = function(targetDate, relative = false) {
     return daysDiff;
   }
 
-  while (start <= end) {
+  while (start < end) {
     if (start.isBusinessDay() && !start.isHoliday()) {
       daysDiff += 1;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -149,14 +149,20 @@ DateTime.prototype.minusBusiness = function({ days = ONE_DAY } = {}) {
 /**
  * Returns the difference in business days.  Set relative to true if you need to support past dates.
  * @param {DateTime} targetDate
- * @param {boolean} relative
+ * @typedef BusinessDiffConfig
+ *  @property {boolean} [includeEndDate=false] includeEndDate
+ *  @property {boolean} [relative=false] relative
+ * @param {BusinessDiffConfig} config
  * @returns {number}
  */
-DateTime.prototype.businessDiff = function(targetDate, relative = false) {
+DateTime.prototype.businessDiff = function(
+  targetDate,
+  { includeEndDate = false, relative = false } = {}
+) {
   let dt = this;
   let start = dt < targetDate ? dt : targetDate;
   let end = dt < targetDate ? targetDate : dt;
-  let daysDiff = 0;
+  let daysDiff = includeEndDate ? 1 : 0;
   let isSameDay =
     dt.hasSame(targetDate, 'day') &&
     dt.hasSame(targetDate, 'month') &&

--- a/src/index.js
+++ b/src/index.js
@@ -147,11 +147,14 @@ DateTime.prototype.minusBusiness = function({ days = ONE_DAY } = {}) {
 };
 
 /**
+ * @typedef BusinessDiffConfig
+ * @property {boolean} [includeEndDate=false] includeEndDate
+ * @property {boolean} [relative=false] relative
+ */
+
+/**
  * Returns the difference in business days.  Set relative to true if you need to support past dates.
  * @param {DateTime} targetDate
- * @typedef BusinessDiffConfig
- *  @property {boolean} [includeEndDate=false] includeEndDate
- *  @property {boolean} [relative=false] relative
  * @param {BusinessDiffConfig} config
  * @returns {number}
  */

--- a/src/index.js
+++ b/src/index.js
@@ -148,8 +148,8 @@ DateTime.prototype.minusBusiness = function({ days = ONE_DAY } = {}) {
 
 /**
  * @typedef BusinessDiffConfig
- * @property {boolean} [includeEndDate=false] includeEndDate
- * @property {boolean} [relative=false] relative
+ * @property {boolean} [includeEndDate=false] - include the end date in the calculation
+ * @property {boolean} [relative=false] - signs the return value as negative if end date is in the past
  */
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -153,7 +153,7 @@ DateTime.prototype.minusBusiness = function({ days = ONE_DAY } = {}) {
  */
 
 /**
- * Returns the difference in business days.  Set relative to true if you need to support past dates.
+ * Returns the difference in business days.
  * @param {DateTime} targetDate
  * @param {BusinessDiffConfig} config
  * @returns {number}

--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,9 @@ DateTime.prototype.diffBusiness = function(
   let dt = this;
   let start = dt < targetDate ? dt : targetDate;
   let end = dt < targetDate ? targetDate : dt;
-  let daysDiff = includeEndDate ? 1 : 0;
+  let daysDiff = Number(
+    includeEndDate && end.isBusinessDay() && !end.isHoliday()
+  );
   let isSameDay =
     dt.hasSame(targetDate, 'day') &&
     dt.hasSame(targetDate, 'month') &&

--- a/src/index.js
+++ b/src/index.js
@@ -146,4 +146,39 @@ DateTime.prototype.minusBusiness = function({ days = ONE_DAY } = {}) {
   return this.plusBusiness({ days: -days });
 };
 
+/**
+ * Returns the difference in business days.  Set relative to true if you need to support past dates.
+ * @param {DateTime} targetDate
+ * @param {boolean} relative
+ * @returns {number}
+ */
+DateTime.prototype.businessDiff = function(targetDate, relative = false) {
+  let dt = this;
+  let start = dt < targetDate ? dt : targetDate;
+  let end = dt < targetDate ? targetDate : dt;
+  let daysDiff = 0;
+  let isSameDay =
+    dt.hasSame(targetDate, 'day') &&
+    dt.hasSame(targetDate, 'month') &&
+    dt.hasSame(targetDate, 'year');
+
+  if (isSameDay) {
+    return daysDiff;
+  }
+
+  while (start < end) {
+    if (start.isBusinessDay() && !start.isHoliday()) {
+      daysDiff += 1;
+    }
+
+    start = start.plus({ days: 1 });
+  }
+
+  if (relative) {
+    return dt <= targetDate ? daysDiff : -daysDiff;
+  }
+
+  return daysDiff;
+};
+
 export { DateTime };

--- a/src/index.js
+++ b/src/index.js
@@ -166,7 +166,7 @@ DateTime.prototype.businessDiff = function(targetDate, relative = false) {
     return daysDiff;
   }
 
-  while (start < end) {
+  while (start <= end) {
     if (start.isBusinessDay() && !start.isHoliday()) {
       daysDiff += 1;
     }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -324,3 +324,39 @@ describe('time zone is carried over after a business-day operation', () => {
     expect(nyPlusTwo.zoneName).toBe('America/New_York');
   });
 });
+
+describe('business day diff', () => {
+  it('knows two identical DateTimes have a business day diff of 0', () => {
+    const targetDate = DateTime.local().plus({ hours: 2 });
+
+    expect(DateTime.local().businessDiff(targetDate)).toEqual(0);
+  });
+
+  it('knows there are three business days between two dates that are 3 business days apart', () => {
+    const myCompanyTakesNoHolidays = [];
+    const startDate = DateTime.local();
+    const futureDate = DateTime.local().plusBusiness({ days: 3 });
+    const pastDate = DateTime.local().minusBusiness({ days: 3 });
+
+    startDate.setupBusiness({
+      holidayMatchers: myCompanyTakesNoHolidays,
+    });
+
+    expect(startDate.businessDiff(futureDate)).toEqual(3);
+    expect(startDate.businessDiff(pastDate)).toEqual(3);
+  });
+
+  it('knows diff is negative for the past and positive for the future if relative is specified', () => {
+    const myCompanyTakesNoHolidays = [];
+    const startDate = DateTime.local();
+    const futureDate = DateTime.local().plusBusiness({ days: 3 });
+    const pastDate = DateTime.local().minusBusiness({ days: 3 });
+
+    startDate.setupBusiness({
+      holidayMatchers: myCompanyTakesNoHolidays,
+    });
+
+    expect(startDate.businessDiff(futureDate, true)).toEqual(3);
+    expect(startDate.businessDiff(pastDate, true)).toEqual(-3);
+  });
+});

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -332,7 +332,7 @@ describe('diffBusiness()', () => {
   it('knows two identical DateTimes have a business day diff of 0', () => {
     const targetDate = defaultStartDate.startOf('day').plus({ hours: 2 });
 
-    expect(DateTime.local().diffBusiness(targetDate)).toEqual(0);
+    expect(defaultStartDate.diffBusiness(targetDate)).toEqual(0);
   });
 
   it('knows there are 3 business days between two dates that are 3 business days apart', () => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -327,16 +327,14 @@ describe('time zone is carried over after a business-day operation', () => {
 
 describe('diffBusiness()', () => {
   it('knows two identical DateTimes have a business day diff of 0', () => {
-    const targetDate = DateTime.local()
-      .startOf('day')
-      .plus({ hours: 2 });
+    const targetDate = DateTime.local().plus({ hours: 2 });
 
     expect(DateTime.local().diffBusiness(targetDate)).toEqual(0);
   });
 
   it('knows there are 3 business days between two dates that are 3 business days apart', () => {
     const myCompanyTakesNoHolidays = [];
-    const startDate = DateTime.local().startOf('day');
+    const startDate = DateTime.local();
     const futureDate = startDate.plusBusiness({ days: 3 });
     const pastDate = startDate.minusBusiness({ days: 3 });
 
@@ -350,7 +348,7 @@ describe('diffBusiness()', () => {
 
   it('knows diff is negative for the past and positive for the future if relative is specified', () => {
     const myCompanyTakesNoHolidays = [];
-    const startDate = DateTime.local().startOf('day');
+    const startDate = DateTime.local();
     const futureDate = startDate.plusBusiness({ days: 3 });
     const pastDate = startDate.minusBusiness({ days: 3 });
 
@@ -366,7 +364,7 @@ describe('diffBusiness()', () => {
 
   it('knows there are 4 business days between two dates that are 3 business days apart but include the end date', () => {
     const myCompanyTakesNoHolidays = [];
-    const startDate = DateTime.local().startOf('day');
+    const startDate = DateTime.local();
     const futureDate = startDate.plusBusiness({ days: 3 });
     const pastDate = startDate.minusBusiness({ days: 3 });
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -326,15 +326,18 @@ describe('time zone is carried over after a business-day operation', () => {
 });
 
 describe('diffBusiness()', () => {
+  // Pick a start date we know is a valid business day
+  const defaultStartDate = DateTime.fromISO('2021-05-03');
+
   it('knows two identical DateTimes have a business day diff of 0', () => {
-    const targetDate = DateTime.local().startOf('day').plus({ hours: 2 });
+    const targetDate = defaultStartDate.startOf('day').plus({ hours: 2 });
 
     expect(DateTime.local().diffBusiness(targetDate)).toEqual(0);
   });
 
   it('knows there are 3 business days between two dates that are 3 business days apart', () => {
     const myCompanyTakesNoHolidays = [];
-    const startDate = DateTime.local();
+    const startDate = defaultStartDate.startOf('day');
     const futureDate = startDate.plusBusiness({ days: 3 });
     const pastDate = startDate.minusBusiness({ days: 3 });
 
@@ -348,7 +351,7 @@ describe('diffBusiness()', () => {
 
   it('knows diff is negative for the past and positive for the future if relative is specified', () => {
     const myCompanyTakesNoHolidays = [];
-    const startDate = DateTime.local();
+    const startDate = defaultStartDate.startOf('day');
     const futureDate = startDate.plusBusiness({ days: 3 });
     const pastDate = startDate.minusBusiness({ days: 3 });
 
@@ -364,7 +367,7 @@ describe('diffBusiness()', () => {
 
   it('knows there are 4 business days between two dates that are 3 business days apart but include the end date', () => {
     const myCompanyTakesNoHolidays = [];
-    const startDate = DateTime.local();
+    const startDate = defaultStartDate.startOf('day');
     const futureDate = startDate.plusBusiness({ days: 3 });
     const pastDate = startDate.minusBusiness({ days: 3 });
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -327,7 +327,7 @@ describe('time zone is carried over after a business-day operation', () => {
 
 describe('diffBusiness()', () => {
   it('knows two identical DateTimes have a business day diff of 0', () => {
-    const targetDate = DateTime.local().plus({ hours: 2 });
+    const targetDate = DateTime.local().startOf('day').plus({ hours: 2 });
 
     expect(DateTime.local().diffBusiness(targetDate)).toEqual(0);
   });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -334,7 +334,7 @@ describe('business day diff', () => {
     expect(DateTime.local().businessDiff(targetDate)).toEqual(0);
   });
 
-  it('knows there are three business days between two dates that are 3 business days apart', () => {
+  it('knows there are 3 business days between two dates that are 3 business days apart', () => {
     const myCompanyTakesNoHolidays = [];
     const startDate = DateTime.local().startOf('day');
     const futureDate = startDate.plusBusiness({ days: 3 });
@@ -358,7 +358,25 @@ describe('business day diff', () => {
       holidayMatchers: myCompanyTakesNoHolidays,
     });
 
-    expect(startDate.businessDiff(futureDate, true)).toEqual(3);
-    expect(startDate.businessDiff(pastDate, true)).toEqual(-3);
+    const config = { relative: true };
+
+    expect(startDate.businessDiff(futureDate, config)).toEqual(3);
+    expect(startDate.businessDiff(pastDate, config)).toEqual(-3);
+  });
+
+  it('knows there are 4 business days between two dates that are 3 business days apart but include the end date', () => {
+    const myCompanyTakesNoHolidays = [];
+    const startDate = DateTime.local().startOf('day');
+    const futureDate = startDate.plusBusiness({ days: 3 });
+    const pastDate = startDate.minusBusiness({ days: 3 });
+
+    startDate.setupBusiness({
+      holidayMatchers: myCompanyTakesNoHolidays,
+    });
+
+    const config = { includeEndDate: true };
+
+    expect(startDate.businessDiff(futureDate, config)).toEqual(4);
+    expect(startDate.businessDiff(pastDate, config)).toEqual(4);
   });
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -327,8 +327,8 @@ describe('time zone is carried over after a business-day operation', () => {
 
 describe('business day diff', () => {
   it('knows two identical DateTimes have a business day diff of 0', () => {
-    const targetDate = DateTime.fromMillis(new Date().setHours(0, 0))
-      .setLocale('America/New_York')
+    const targetDate = DateTime.local()
+      .startOf('day')
       .plus({ hours: 2 });
 
     expect(DateTime.local().businessDiff(targetDate)).toEqual(0);
@@ -336,9 +336,9 @@ describe('business day diff', () => {
 
   it('knows there are three business days between two dates that are 3 business days apart', () => {
     const myCompanyTakesNoHolidays = [];
-    const startDate = DateTime.local();
-    const futureDate = DateTime.local().plusBusiness({ days: 3 });
-    const pastDate = DateTime.local().minusBusiness({ days: 3 });
+    const startDate = DateTime.local().startOf('day');
+    const futureDate = startDate.plusBusiness({ days: 3 });
+    const pastDate = startDate.minusBusiness({ days: 3 });
 
     startDate.setupBusiness({
       holidayMatchers: myCompanyTakesNoHolidays,
@@ -350,9 +350,9 @@ describe('business day diff', () => {
 
   it('knows diff is negative for the past and positive for the future if relative is specified', () => {
     const myCompanyTakesNoHolidays = [];
-    const startDate = DateTime.local();
-    const futureDate = DateTime.local().plusBusiness({ days: 3 });
-    const pastDate = DateTime.local().minusBusiness({ days: 3 });
+    const startDate = DateTime.local().startOf('day');
+    const futureDate = startDate.plusBusiness({ days: 3 });
+    const pastDate = startDate.minusBusiness({ days: 3 });
 
     startDate.setupBusiness({
       holidayMatchers: myCompanyTakesNoHolidays,

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -325,7 +325,7 @@ describe('time zone is carried over after a business-day operation', () => {
   });
 });
 
-describe('business day diff', () => {
+describe('diffBusiness()', () => {
   it('knows two identical DateTimes have a business day diff of 0', () => {
     const targetDate = DateTime.local()
       .startOf('day')

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -327,7 +327,9 @@ describe('time zone is carried over after a business-day operation', () => {
 
 describe('business day diff', () => {
   it('knows two identical DateTimes have a business day diff of 0', () => {
-    const targetDate = DateTime.local().plus({ hours: 2 });
+    const targetDate = DateTime.fromMillis(new Date().setHours(0, 0))
+      .setLocale('America/New_York')
+      .plus({ hours: 2 });
 
     expect(DateTime.local().businessDiff(targetDate)).toEqual(0);
   });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -331,7 +331,7 @@ describe('diffBusiness()', () => {
       .startOf('day')
       .plus({ hours: 2 });
 
-    expect(DateTime.local().businessDiff(targetDate)).toEqual(0);
+    expect(DateTime.local().diffBusiness(targetDate)).toEqual(0);
   });
 
   it('knows there are 3 business days between two dates that are 3 business days apart', () => {
@@ -344,8 +344,8 @@ describe('diffBusiness()', () => {
       holidayMatchers: myCompanyTakesNoHolidays,
     });
 
-    expect(startDate.businessDiff(futureDate)).toEqual(3);
-    expect(startDate.businessDiff(pastDate)).toEqual(3);
+    expect(startDate.diffBusiness(futureDate)).toEqual(3);
+    expect(startDate.diffBusiness(pastDate)).toEqual(3);
   });
 
   it('knows diff is negative for the past and positive for the future if relative is specified', () => {
@@ -360,8 +360,8 @@ describe('diffBusiness()', () => {
 
     const config = { relative: true };
 
-    expect(startDate.businessDiff(futureDate, config)).toEqual(3);
-    expect(startDate.businessDiff(pastDate, config)).toEqual(-3);
+    expect(startDate.diffBusiness(futureDate, config)).toEqual(3);
+    expect(startDate.diffBusiness(pastDate, config)).toEqual(-3);
   });
 
   it('knows there are 4 business days between two dates that are 3 business days apart but include the end date', () => {
@@ -376,7 +376,7 @@ describe('diffBusiness()', () => {
 
     const config = { includeEndDate: true };
 
-    expect(startDate.businessDiff(futureDate, config)).toEqual(4);
-    expect(startDate.businessDiff(pastDate, config)).toEqual(4);
+    expect(startDate.diffBusiness(futureDate, config)).toEqual(4);
+    expect(startDate.diffBusiness(pastDate, config)).toEqual(4);
   });
 });


### PR DESCRIPTION
Added businessDiff method to get number of business days between DateTimes.

After completing the switch from Moment to Luxon, I realized this functionality was missing in this library.  The solution was to borrow from https://github.com/kalmecak/moment-business-days/blob/master/index.js.

Usage:

```js
const targetDate = DateTime.local().plusBusiness({ days: 10 });

const businessDaysDiff = DateTime.local().businessDiff(targetDate);

// businessDaysDiff = 10
```