### PR TITLE
Add Custom business days matcher on plusBusiness and minusBusinees

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,8 @@ dt.isHoliday('middle-america', {some: 'stuff'});
     * [.clearBusinessSetup()](#DateTime+clearBusinessSetup) ⇐ [<code>DateTime</code>](#DateTime)
     * [.isHoliday([...args])](#DateTime+isHoliday) ⇒ <code>boolean</code>
     * [.isBusinessDay([businessDays])](#DateTime+isBusinessDay) ⇒ <code>boolean</code>
-    * [.plusBusiness([days], [businessDays])](#DateTime+plusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
-    * [.minusBusiness([days], [businessDays])](#DateTime+minusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
+    * [.plusBusiness([days], [customBusinessDays])](#DateTime+plusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
+    * [.minusBusiness([days], [customBusinessDays])](#DateTime+minusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
 
 <a name="DateTime+availableHolidayMatchers"></a>
 
@@ -352,7 +352,7 @@ Checks if DateTime instance is a business day.
 
 <a name="DateTime+plusBusiness"></a>
 
-### dateTime.plusBusiness([days], [businessDays]) ⇒ [<code>DateTime</code>](#DateTime)
+### dateTime.plusBusiness([days], [customBusinessDays]) ⇒ [<code>DateTime</code>](#DateTime)
 Adds business days to an existing DateTime instance.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
@@ -361,11 +361,11 @@ Adds business days to an existing DateTime instance.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | [days] | <code>number</code> | <code>1</code> | The number of business days to add. |
-| [businessDays] | <code>Array.&lt;number&gt;</code> \| <code>undefined</code> | <code>undefined | DEFAULT_BUSINESS_DAYS</code> | The working business days for the business. |
+| [customBusinessDays] | <code>Array.&lt;number&gt;</code> \| <code>undefined</code> | <code>undefined | DEFAULT_BUSINESS_DAYS</code> | The working business days for the business. |
 
 <a name="DateTime+minusBusiness"></a>
 
-### dateTime.minusBusiness([days], [businessDays]) ⇒ [<code>DateTime</code>](#DateTime)
+### dateTime.minusBusiness([days], [customBusinessDays]) ⇒ [<code>DateTime</code>](#DateTime)
 Subtracts business days to an existing DateTime instance.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
@@ -374,7 +374,7 @@ Subtracts business days to an existing DateTime instance.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | [days] | <code>number</code> | <code>1</code> | The number of business days to subtract. |
-| [businessDays] | <code>Array.&lt;number&gt;</code> \| <code>undefined</code> | <code>undefined | DEFAULT_BUSINESS_DAYS</code> | The working business days for the business. |
+| [customBusinessDays] | <code>Array.&lt;number&gt;</code> \| <code>undefined</code> | <code>undefined | DEFAULT_BUSINESS_DAYS</code> | The working business days for the business. |
 
 <a name="getEasterMonthAndDay"></a>
 

--- a/README.md
+++ b/README.md
@@ -268,9 +268,9 @@ dt.isHoliday('middle-america', {some: 'stuff'});
     * [.setupBusiness([businessDays], [holidayMatchers])](#DateTime+setupBusiness) ⇐ [<code>DateTime</code>](#DateTime)
     * [.clearBusinessSetup()](#DateTime+clearBusinessSetup) ⇐ [<code>DateTime</code>](#DateTime)
     * [.isHoliday([...args])](#DateTime+isHoliday) ⇒ <code>boolean</code>
-    * [.isBusinessDay()](#DateTime+isBusinessDay) ⇒ <code>boolean</code>
-    * [.plusBusiness([days])](#DateTime+plusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
-    * [.minusBusiness([days])](#DateTime+minusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
+    * [.isBusinessDay([businessDays])](#DateTime+isBusinessDay) ⇒ <code>boolean</code>
+    * [.plusBusiness([days], [businessDays])](#DateTime+plusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
+    * [.minusBusiness([days], [businessDays])](#DateTime+minusBusiness) ⇒ [<code>DateTime</code>](#DateTime)
 
 <a name="DateTime+availableHolidayMatchers"></a>
 
@@ -340,14 +340,19 @@ Checks if DateTime instance is a holiday by checking against all holiday matcher
 
 <a name="DateTime+isBusinessDay"></a>
 
-### dateTime.isBusinessDay() ⇒ <code>boolean</code>
+### dateTime.isBusinessDay([businessDays]) ⇒ <code>boolean</code>
 Checks if DateTime instance is a business day.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
 **Extends**: [<code>DateTime</code>](#DateTime)  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [businessDays] | <code>Array.&lt;number&gt;</code> \| <code>undefined</code> | <code>undefined | DEFAULT_BUSINESS_DAYS</code> | The working business days for the business. |
+
 <a name="DateTime+plusBusiness"></a>
 
-### dateTime.plusBusiness([days]) ⇒ [<code>DateTime</code>](#DateTime)
+### dateTime.plusBusiness([days], [businessDays]) ⇒ [<code>DateTime</code>](#DateTime)
 Adds business days to an existing DateTime instance.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
@@ -356,10 +361,11 @@ Adds business days to an existing DateTime instance.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | [days] | <code>number</code> | <code>1</code> | The number of business days to add. |
+| [businessDays] | <code>Array.&lt;number&gt;</code> \| <code>undefined</code> | <code>undefined | DEFAULT_BUSINESS_DAYS</code> | The working business days for the business. |
 
 <a name="DateTime+minusBusiness"></a>
 
-### dateTime.minusBusiness([days]) ⇒ [<code>DateTime</code>](#DateTime)
+### dateTime.minusBusiness([days], [businessDays]) ⇒ [<code>DateTime</code>](#DateTime)
 Subtracts business days to an existing DateTime instance.
 
 **Kind**: instance method of [<code>DateTime</code>](#DateTime)  
@@ -368,6 +374,7 @@ Subtracts business days to an existing DateTime instance.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | [days] | <code>number</code> | <code>1</code> | The number of business days to subtract. |
+| [businessDays] | <code>Array.&lt;number&gt;</code> \| <code>undefined</code> | <code>undefined | DEFAULT_BUSINESS_DAYS</code> | The working business days for the business. |
 
 <a name="getEasterMonthAndDay"></a>
 

--- a/src/index.js
+++ b/src/index.js
@@ -96,10 +96,12 @@ DateTime.prototype.isHoliday = function(...args) {
 /**
  * Checks if DateTime instance is a business day.
  * @augments DateTime
+ * @param {Array<number> | undefined} [businessDays=undefined | DEFAULT_BUSINESS_DAYS] - The working business days for the business.
  * @returns {boolean}
  */
-DateTime.prototype.isBusinessDay = function() {
-  const businessDays = this.businessDays || DEFAULT_BUSINESS_DAYS;
+DateTime.prototype.isBusinessDay = function(customBusinessDays) {
+  const businessDays =
+    customBusinessDays || this.businessDays || DEFAULT_BUSINESS_DAYS;
 
   return businessDays.includes(this.weekday);
 };
@@ -108,9 +110,13 @@ DateTime.prototype.isBusinessDay = function() {
  * Adds business days to an existing DateTime instance.
  * @augments DateTime
  * @param {number} [days=1] - The number of business days to add.
+ * @param {Array<number> | undefined} [customBusinessDays=undefined | DEFAULT_BUSINESS_DAYS] - The working business days for the business.
  * @returns {DateTime}
  */
-DateTime.prototype.plusBusiness = function({ days = ONE_DAY } = {}) {
+DateTime.prototype.plusBusiness = function({
+  days = ONE_DAY,
+  customBusinessDays,
+} = {}) {
   let dt = this;
 
   if (!dt.isValid) {
@@ -128,7 +134,7 @@ DateTime.prototype.plusBusiness = function({ days = ONE_DAY } = {}) {
 
     dt = dt.plus({ days: oneDayByDirection });
 
-    if (dt.isBusinessDay() && !dt.isHoliday()) {
+    if (dt.isBusinessDay(customBusinessDays) && !dt.isHoliday()) {
       businessDaysLeftToAdd--;
     }
   }
@@ -140,10 +146,14 @@ DateTime.prototype.plusBusiness = function({ days = ONE_DAY } = {}) {
  * Subtracts business days to an existing DateTime instance.
  * @augments DateTime
  * @param {number} [days=1] - The number of business days to subtract.
+ * @param {Array<number> | undefined} [customBusinessDays=undefined | DEFAULT_BUSINESS_DAYS] - The working business days for the business.
  * @returns {DateTime}
  */
-DateTime.prototype.minusBusiness = function({ days = ONE_DAY } = {}) {
-  return this.plusBusiness({ days: -days });
+DateTime.prototype.minusBusiness = function({
+  days = ONE_DAY,
+  customBusinessDays,
+} = {}) {
+  return this.plusBusiness({ days: -days, customBusinessDays });
 };
 
 export { DateTime };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -153,7 +153,7 @@ describe('isBusinessDay()', () => {
     });
   });
 
-  it('knows when overridden business settings are business days', () => {
+  it('knows when overridden global business settings are business days', () => {
     const monday = [2019, 8, 26];
     let dt = DateTime.local(...monday);
     dt.setupBusiness({ businessDays: [2, 4, 7] });
@@ -170,6 +170,29 @@ describe('isBusinessDay()', () => {
 
     Object.values(days).forEach(({ isBusinessDay }) => {
       expect(dt.isBusinessDay()).toEqual(isBusinessDay);
+
+      dt = dt.plus({ days: 1 });
+    });
+  });
+
+  it('knows when custom business days are passed', () => {
+    const monday = [2019, 8, 26];
+    let dt = DateTime.local(...monday);
+    const customBusinessDays = [1, 2, 4, 7];
+    dt.setupBusiness({ businessDays: customBusinessDays });
+
+    const days = {
+      monday: { isBusinessDay: true },
+      tuesday: { isBusinessDay: true },
+      wednesday: { isBusinessDay: false },
+      thursday: { isBusinessDay: true },
+      friday: { isBusinessDay: false },
+      saturday: { isBusinessDay: false },
+      sunday: { isBusinessDay: true },
+    };
+
+    Object.values(days).forEach(({ isBusinessDay }) => {
+      expect(dt.isBusinessDay(customBusinessDays)).toEqual(isBusinessDay);
 
       dt = dt.plus({ days: 1 });
     });
@@ -233,7 +256,24 @@ describe('plusBusiness()', () => {
     expect(+wednesdayPlusBusinessDays === +friday).toBe(true);
   });
 
-  it('knows how add a negative number of days (aka add days)', () => {
+  it('knows how to add business days when custom business days are passed', () => {
+    const dt = DateTime.local(2019, 7, 3);
+    const customBusinessDays = [1, 2, 3, 4, 6]; // Saturday is a business day, but Friday is not.
+    const saturday = DateTime.local(2019, 7, 6);
+    const myCompanyTakesNoHolidays = [];
+    dt.setupBusiness({
+      holidayMatchers: myCompanyTakesNoHolidays,
+    });
+    const wednesdayPlusBusinessDays = dt.plusBusiness({
+      days: 2,
+      customBusinessDays,
+    });
+    console.log(wednesdayPlusBusinessDays.toJSDate());
+
+    expect(+wednesdayPlusBusinessDays === +saturday).toBe(true);
+  });
+
+  it('knows how add a negative number of days (aka subtract days)', () => {
     const wednesday = DateTime.local(2019, 7, 3);
     const tuesday = DateTime.local(2019, 7, 2);
     const dayBeforeWednesday = wednesday.plusBusiness({ days: -1 });
@@ -265,6 +305,18 @@ describe('minusBusiness()', () => {
     const tuesdayMinusBusinessDays = tuesday.minusBusiness({ days: 3 });
 
     expect(+tuesdayMinusBusinessDays === +previousThursday).toBe(true);
+  });
+
+  it('knows how to subtract business days when custom business days are passed', () => {
+    const tuesday = DateTime.local(2019, 8, 27);
+    const previousFriday = DateTime.local(2019, 8, 22);
+    const customBusinessDays = [1, 2, 3, 4, 6]; // Saturday is a business day, but Friday is not.
+    const tuesdayMinusBusinessDays = tuesday.minusBusiness({
+      days: 3,
+      customBusinessDays,
+    });
+
+    expect(+tuesdayMinusBusinessDays === +previousFriday).toBe(true);
   });
 
   it('knows how to subtract negative business days (aka add days)', () => {


### PR DESCRIPTION
This is a step in the direction of resolving Issuehttps://github.com/amaidah/luxon-business-days/issues/63. We are allowing adding customBusinsessDays matchers in `isBusinessDay`, `plusBusiness` and `minusBusiness` functions, so that it allows us to have custom business days without having to update businessDays globally.